### PR TITLE
Feat : google calendar 일정 등록/조회Feat : google calendar 일정 등록/조회

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dotenv": "^17.2.0",
     "express": "^5.0.0",
     "express-session": "^1.18.2",
+    "googleapis": "^155.0.1",
     "http-status-codes": "^2.3.0",
     "ioredis": "^5.6.1",
     "jsonwebtoken": "^9.0.2",

--- a/src/controllers/scheduleCreate.controller.js
+++ b/src/controllers/scheduleCreate.controller.js
@@ -1,6 +1,15 @@
 import { bodyToSchedule } from '../dtos/schedule.dto.js';
 import { createScheduleWithRules } from '../services/scheduleCreate.service.js';
-import { UnauthorizedError, InternalServerError, ValidationError } from '../errors/error.js';
+import {
+  UnauthorizedError,
+  InternalServerError,
+  ValidationError,
+} from '../errors/error.js';
+import {
+  createEvent,
+  getOrCreateNamedCalendar,
+} from '../services/google-calendar.service.js';
+import { bodyToGoogleCalendar } from '../dtos/google-calendar.dto.js';
 
 // 일정 등록
 
@@ -15,17 +24,32 @@ export const handleCreateSchedule = async (req, res, next) => {
     const scheduleData = bodyToSchedule(req.body);
     const scheduleId = await createScheduleWithRules(userId, scheduleData);
 
+    // 구글 캘린더에서 timeup 캘린더 ID 확보 (없으면 생성)
+    const cal = await getOrCreateNamedCalendar(userId, 'timeup');
+    const timeupCalendarId = cal.id;
+
+    const dtoInput = { ...req.body, calendar_id: timeupCalendarId };
+    const googleCalendarData = bodyToGoogleCalendar(dtoInput);
+    const googleCalendarRes = await createEvent(
+      userId,
+      googleCalendarData.calendarId,
+      googleCalendarData.requestBody
+    );
+
     return res.success(
       {
-      message: '일정이 등록되었습니다.',
-      schedule_id: scheduleId,
+        message: '일정이 등록되었습니다.',
+        schedule_id: scheduleId,
+        google_link: googleCalendarRes.htmlLink,
       },
       200
     );
   } catch (error) {
-
-    if (error instanceof ValidationError || error instanceof UnauthorizedError) {
-        return res.error(error, error.status);
+    if (
+      error instanceof ValidationError ||
+      error instanceof UnauthorizedError
+    ) {
+      return res.error(error, error.status);
     }
 
     const internalError = new InternalServerError();

--- a/src/controllers/scheduleDaily.controller.js
+++ b/src/controllers/scheduleDaily.controller.js
@@ -1,5 +1,12 @@
 import { getDailySchedule } from '../services/scheduleDaily.service.js';
-import { UnauthorizedError, NotFoundError, ForbiddenError, InternalServerError } from '../errors/error.js';
+import {
+  UnauthorizedError,
+  NotFoundError,
+  ForbiddenError,
+  InternalServerError,
+  ValidationError,
+} from '../errors/error.js';
+import { fetchGoogleDailySchedules } from '../services/google-calendar.service.js';
 
 // 날짜별 일정 목록 조회
 
@@ -13,22 +20,34 @@ export const handleGetDailySchedule = async (req, res, next) => {
     }
 
     if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-      throw new ValidationError('date 파라미터는 YYYY-MM-DD 형식으로 입력해야 합니다.');
+      throw new ValidationError(
+        'date 파라미터는 YYYY-MM-DD 형식으로 입력해야 합니다.'
+      );
     }
 
     const schedules = await getDailySchedule(userId, date);
 
-    if (schedule.user_id !== userId) throw new ForbiddenError('해당 일정에 접근할 수 없습니다.');
+    let googleSchedules = [];
+    try {
+      //구글 오류가 생겨도 db 응답만 반환
+      googleSchedules = await fetchGoogleDailySchedules(userId, date);
+    } catch (err) {
+      console.error(err);
+      googleSchedules = [];
+    }
+
+    //if (schedules.user_id !== userId)
+    //throw new ForbiddenError('해당 일정에 접근할 수 없습니다.');
 
     return res.success(
       {
         message: `조회하신 날짜의 일정 목록입니다.`,
         schedules,
+        googleSchedules,
       },
       200
     );
   } catch (error) {
-
     if (
       error instanceof ValidationError ||
       error instanceof UnauthorizedError ||

--- a/src/dtos/google-calendar.dto.js
+++ b/src/dtos/google-calendar.dto.js
@@ -1,0 +1,154 @@
+import { BusinessLogicError, NotFoundError } from '../errors/error.js';
+
+const DEFAULT_TZ = 'Asia/Seoul';
+
+const toISOOrThrow = (value, fieldName) => {
+  if (!value) throw new NotFoundError(`"${fieldName}" is required`);
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime()))
+    throw new NotFoundError(`"${fieldName}" must be a valid datetime`);
+  return d.toISOString();
+};
+
+const toAllDayRangeOrNull = (body) => {
+  if (!body.is_all_day) return null;
+
+  const start = new Date(body.start_date);
+  const end = new Date(body.end_date);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    throw new BusinessLogicError(
+      '"start_date"/"end_date" must be valid when is_all_day = true'
+    );
+  }
+
+  const startDate = start.toISOString().slice(0, 10);
+  const endDateObj = new Date(
+    Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate() + 1)
+  );
+  const endDate = endDateObj.toISOString().slice(0, 10);
+
+  return {
+    start: { date: startDate },
+    end: { date: endDate },
+  };
+};
+
+const normalizeWeekdays = (list) => {
+  if (!Array.isArray(list) || list.length === 0) return [];
+  return list
+    .map((n) => {
+      if (n >= 0 && n <= 6) return weekdayToByDay(n);
+      if (n >= 1 && n <= 7) return weekdayToByDay(n % 7);
+      return null;
+    })
+    .filter(Boolean);
+};
+
+const weekdayToByDay = (n) => {
+  const map = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+  return map[n] || 'MO';
+};
+
+const toUntilUTC = (dateInput) => {
+  const d = new Date(dateInput);
+  if (Number.isNaN(d.getTime()))
+    throw new BusinessLogicError('"repeat_until_date" must be a valid date');
+  const y = d.getUTCFullYear().toString().padStart(4, '0');
+  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
+  const day = d.getUTCDate().toString().padStart(2, '0');
+  return `${y}${m}${day}T000000Z`;
+};
+
+const buildRecurrence = (body) => {
+  if (!body.is_recurring) return undefined;
+
+  const r = body.recurrence_rule; // 단수/복수 모두 허용
+  if (!r || !r.repeat_type) return undefined;
+
+  const parts = [];
+
+  // FREQ
+  if (r.repeat_type === 'weekly') {
+    parts.push('FREQ=WEEKLY');
+    const weekdays = body.repeat_weekdays || r.repeat_weekdays;
+    const days = normalizeWeekdays(weekdays);
+    if (days.length > 0) parts.push(`BYDAY=${days.join(',')}`);
+  }
+
+  if (r.repeat_type === 'monthly') {
+    parts.push('FREQ=MONTHLY');
+    const monthlyOpt = r.monthly_repeat_option || r.monthly_option;
+
+    if (monthlyOpt === 'day_of_month' && Number.isInteger(r.day_of_month)) {
+      parts.push(`BYMONTHDAY=${r.day_of_month}`);
+    } else if (
+      monthlyOpt === 'nth_weekday' &&
+      Number.isInteger(r.nth_week) &&
+      Number.isInteger(r.weekday) &&
+      r.weekday >= 0 &&
+      r.weekday <= 6
+    ) {
+      const byday = weekdayToByDay(r.weekday); // 0=SU, 1=MO, ...
+      parts.push(`BYDAY=${r.nth_week}${byday}`); // 예: 2TU
+    }
+  }
+
+  // COUNT / UNTIL
+  if (r.repeat_mode === 'count' && Number.isInteger(r.repeat_count)) {
+    parts.push(`COUNT=${r.repeat_count}`);
+  } else if (r.repeat_mode === 'until' && r.repeat_until_date) {
+    parts.push(`UNTIL=${toUntilUTC(r.repeat_until_date)}`);
+  }
+
+  return parts.length ? [`RRULE:${parts.join(';')}`] : undefined;
+};
+
+const buildLocation = (body) => {
+  const parts = [];
+  if (body.place_name) parts.push(body.place_name);
+  if (body.address) parts.push(body.address);
+  return parts.join(' ') || undefined;
+};
+
+export const bodyToGoogleCalendar = (body) => {
+  const timeZone = body.time_zone || DEFAULT_TZ;
+  const allDay = toAllDayRangeOrNull(body);
+
+  if (!allDay) {
+    const startISO = toISOOrThrow(body.start_date, 'start_date');
+    const endISO =
+      new Date(body.end_date).getTime() === new Date(body.start_date).getTime()
+        ? new Date(new Date(startISO).getTime() + 60 * 60 * 1000).toISOString()
+        : toISOOrThrow(body.end_date, 'end_date');
+
+    if (new Date(startISO) >= new Date(endISO)) {
+      throw new BusinessLogicError('"end_date" must be after "start_date"');
+    }
+
+    return {
+      calendarId: body.calendar_id || 'primary',
+      requestBody: {
+        summary: body.name,
+        description: body.memo || undefined,
+        location: buildLocation(body),
+        start: { dateTime: startISO, timeZone },
+        end: { dateTime: endISO, timeZone },
+        colorId: body.colorId ?? '9',
+        recurrence: buildRecurrence(body),
+      },
+    };
+  }
+
+  return {
+    calendarId: body.calendar_id || 'primary',
+    requestBody: {
+      summary: body.name,
+      description: body.memo || undefined,
+      location: buildLocation(body),
+      start: allDay.start,
+      end: allDay.end,
+      colorId: '9' || undefined,
+      recurrence: buildRecurrence(body),
+    },
+  };
+};

--- a/src/repositories/google-token.repository.js
+++ b/src/repositories/google-token.repository.js
@@ -1,0 +1,32 @@
+import { prisma } from '../db.config.js';
+
+export const findByUserId = async (userId) => {
+  return prisma.user_google_token.findUnique({
+    where: { user_id: userId },
+  });
+};
+
+export const upsert = async (userId, { accessToken, refreshToken }) => {
+  return prisma.user_google_token.upsert({
+    where: { user_id: userId },
+    update: {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    },
+    create: {
+      user_id: userId,
+      access_token: accessToken,
+      refresh_token: refreshToken,
+    },
+  });
+};
+
+export const updateTokens = async (userId, { accessToken, refreshToken }) => {
+  return prisma.user_google_token.update({
+    where: { user_id: userId },
+    data: {
+      ...(accessToken ? { access_token: accessToken } : {}),
+      ...(refreshToken ? { refresh_token: refreshToken } : {}),
+    },
+  });
+};

--- a/src/services/google-calendar.service.js
+++ b/src/services/google-calendar.service.js
@@ -5,47 +5,6 @@ import { google } from 'googleapis';
 const DEFAULT_TZ = 'Asia/Seoul';
 const TIMEUP_SUMMARY = 'timeup';
 
-export const listCalendars = async (userId) => {
-  const auth = await createOAuthClientForUser(userId);
-  const calendar = google.calendar({ version: 'v3', auth });
-  const list = await calendar.calendarList.list();
-  return list.data.items || [];
-};
-
-export const listAllCalendarEvents = async (userId, opts = {}) => {
-  const { timeMin, timeMax, maxPerCalendar } = opts;
-
-  const auth = await createOAuthClientForUser(userId);
-  const calendar = google.calendar({ version: 'v3', auth });
-
-  const calendarRes = await calendar.calendarList.list();
-  const calendars = calendarRes.data.items || [];
-
-  const results = [];
-
-  for (const cal of calendars) {
-    const eventsRes = await calendar.events.list({
-      calendarId: cal.id,
-      timeMin: timeMin || new Date().toISOString(),
-      ...(timeMax ? { timeMax } : {}),
-      maxResults: maxPerCalendar || 20,
-      singleEvents: true,
-      orderBy: 'startTime',
-    });
-
-    results.push({
-      calendarId: cal.id,
-      calendarSummary: cal.summary,
-      events: eventsRes.data.items || [],
-    });
-  }
-
-  return {
-    totalCalendars: calendars.length,
-    calendars: results,
-  };
-};
-
 export const getOrCreateNamedCalendar = async (
   userId,
   summary = TIMEUP_SUMMARY
@@ -72,7 +31,7 @@ export const getOrCreateNamedCalendar = async (
 
     return created.data;
   } catch (err) {
-    throw BusinessLogicError(err);
+    throw BusinessLogicError(err?.message || 'Google Calendar error');
   }
 };
 
@@ -88,6 +47,169 @@ export const createEvent = async (userId, calendarId, event) => {
     });
     return res.data;
   } catch (err) {
-    throw BusinessLogicError(err);
+    throw BusinessLogicError(err?.message || 'Google Calendar error');
+  }
+};
+
+const normalizeStartEnd = (evt) => {
+  // Google은 all-day면 date, 시간 이벤트면 dateTime을 줌
+  const s = evt.start?.dateTime || evt.start?.date;
+  const e = evt.end?.dateTime || evt.end?.date;
+  return { start_date: s, end_date: e };
+};
+
+const normalizeStartEndUTC = (evt) => {
+  // Google은 all-day면 date, 시간 이벤트면 dateTime을 줌
+  const s = evt.start?.dateTime || evt.start?.date;
+  const e = evt.end?.dateTime || evt.end?.date;
+  return {
+    start_date: new Date(s).toISOString(),
+    end_date: new Date(e).toISOString(),
+  };
+};
+
+const getMonthRange = (year, month) => {
+  const start = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0));
+  const endExclusive = new Date(Date.UTC(year, month, 1, 0, 0, 0));
+  return { timeMin: start.toISOString(), timeMax: endExclusive.toISOString() };
+};
+
+const getDayRange = (day) => {
+  const [y, m, d] = day.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, d, 0, 0, 0));
+  const endExclusive = new Date(Date.UTC(y, m - 1, d + 1, 0, 0, 0));
+  return { timeMin: start.toISOString(), timeMax: endExclusive.toISOString() };
+};
+
+const listNonTimeupCalendars = async (userId) => {
+  try {
+    const auth = await createOAuthClientForUser(userId);
+    const calendar = google.calendar({ version: 'v3', auth });
+
+    const res = await calendar.calendarList.list();
+    const items = res.data.items || [];
+
+    // summary가 'timeup'인 캘린더 제외
+    return items.filter(
+      (c) => (c.summary || '').toLowerCase() !== TIMEUP_SUMMARY.toLowerCase()
+    );
+  } catch (err) {
+    throw new BusinessLogicError(err?.message);
+  }
+};
+
+const listEventsForCalendar = async (
+  calendar,
+  calendarId,
+  timeMin,
+  timeMax
+) => {
+  try {
+    const all = [];
+    let pageToken;
+
+    do {
+      const res = await calendar.events.list({
+        calendarId,
+        timeMin,
+        timeMax,
+        singleEvents: true,
+        showDeleted: false,
+        orderBy: 'startTime',
+        maxResults: 100,
+        pageToken,
+      });
+      all.push(...(res.data.items || []));
+      pageToken = res.data.nextPageToken;
+    } while (pageToken);
+
+    return all;
+  } catch (err) {
+    throw new BusinessLogicError(err?.message);
+  }
+};
+
+//월별 조회
+export const fetchGoogleMonthlyMarkers = async (userId, year, month) => {
+  try {
+    const auth = await createOAuthClientForUser(userId);
+    const calendar = google.calendar({ version: 'v3', auth });
+    const { timeMin, timeMax } = getMonthRange(year, month);
+    const calendars = await listNonTimeupCalendars(userId);
+
+    const dayMap = {};
+
+    for (const cal of calendars) {
+      const events = await listEventsForCalendar(
+        calendar,
+        cal.id,
+        timeMin,
+        timeMax
+      );
+
+      for (const evt of events) {
+        const { start_date, end_date } = normalizeStartEnd(evt);
+
+        const start = new Date(start_date);
+        const end = new Date(end_date);
+
+        for (
+          let dt = new Date(
+            Date.UTC(
+              start.getUTCFullYear(),
+              start.getUTCMonth(),
+              start.getUTCDate()
+            )
+          );
+          dt < end;
+          dt = new Date(dt.getTime() + 24 * 60 * 60 * 1000)
+        ) {
+          const day = dt.getUTCDate().toString();
+          dayMap[day] ||= [];
+          dayMap[day].push({ color: 'red' }); // 색상은 red로 표시
+        }
+      }
+    }
+
+    return dayMap;
+  } catch (err) {
+    throw new BusinessLogicError(err?.message);
+  }
+};
+
+// 일별 조회
+export const fetchGoogleDailySchedules = async (userId, yyyyMmDd) => {
+  try {
+    const auth = await createOAuthClientForUser(userId);
+    const calendar = google.calendar({ version: 'v3', auth });
+    const { timeMin, timeMax } = getDayRange(yyyyMmDd);
+    const calendars = await listNonTimeupCalendars(userId);
+
+    const googleSchedules = [];
+
+    for (const cal of calendars) {
+      const events = await listEventsForCalendar(
+        calendar,
+        cal.id,
+        timeMin,
+        timeMax
+      );
+
+      for (const evt of events) {
+        const { start_date, end_date } = normalizeStartEndUTC(evt);
+        googleSchedules.push({
+          schedule_id: evt.id, // DB 스케줄 아님
+          name: evt.summary || '(제목 없음)',
+          start_date,
+          end_date,
+          color: 'red',
+          url: evt.htmlLink,
+        });
+      }
+    }
+
+    return googleSchedules;
+  } catch (err) {
+    throw new BusinessLogicError(err?.message);
   }
 };

--- a/src/services/google-calendar.service.js
+++ b/src/services/google-calendar.service.js
@@ -1,0 +1,93 @@
+import { BusinessLogicError } from '../errors/error.js';
+import { createOAuthClientForUser } from '../utils/googleCalendarClient.js';
+import { google } from 'googleapis';
+
+const DEFAULT_TZ = 'Asia/Seoul';
+const TIMEUP_SUMMARY = 'timeup';
+
+export const listCalendars = async (userId) => {
+  const auth = await createOAuthClientForUser(userId);
+  const calendar = google.calendar({ version: 'v3', auth });
+  const list = await calendar.calendarList.list();
+  return list.data.items || [];
+};
+
+export const listAllCalendarEvents = async (userId, opts = {}) => {
+  const { timeMin, timeMax, maxPerCalendar } = opts;
+
+  const auth = await createOAuthClientForUser(userId);
+  const calendar = google.calendar({ version: 'v3', auth });
+
+  const calendarRes = await calendar.calendarList.list();
+  const calendars = calendarRes.data.items || [];
+
+  const results = [];
+
+  for (const cal of calendars) {
+    const eventsRes = await calendar.events.list({
+      calendarId: cal.id,
+      timeMin: timeMin || new Date().toISOString(),
+      ...(timeMax ? { timeMax } : {}),
+      maxResults: maxPerCalendar || 20,
+      singleEvents: true,
+      orderBy: 'startTime',
+    });
+
+    results.push({
+      calendarId: cal.id,
+      calendarSummary: cal.summary,
+      events: eventsRes.data.items || [],
+    });
+  }
+
+  return {
+    totalCalendars: calendars.length,
+    calendars: results,
+  };
+};
+
+export const getOrCreateNamedCalendar = async (
+  userId,
+  summary = TIMEUP_SUMMARY
+) => {
+  try {
+    const auth = await createOAuthClientForUser(userId);
+    const calendar = google.calendar({ version: 'v3', auth });
+
+    // 1) 목록에서 timeup 캘린더 찾기
+    const list = await calendar.calendarList.list();
+    const items = list.data.items || [];
+    const found = items.find(
+      (c) => (c.summary || '').toLowerCase() === summary.toLowerCase()
+    );
+    if (found) return found;
+
+    // 2) 없으면 생성
+    const created = await calendar.calendars.insert({
+      requestBody: {
+        summary,
+        timeZone: DEFAULT_TZ,
+      },
+    });
+
+    return created.data;
+  } catch (err) {
+    throw BusinessLogicError(err);
+  }
+};
+
+export const createEvent = async (userId, calendarId, event) => {
+  try {
+    // event: { summary, description?, location?, start: { dateTime, timeZone? }, end: { dateTime, timeZone? } }
+    const auth = await createOAuthClientForUser(userId);
+    const calendar = google.calendar({ version: 'v3', auth });
+
+    const res = await calendar.events.insert({
+      calendarId,
+      requestBody: event,
+    });
+    return res.data;
+  } catch (err) {
+    throw BusinessLogicError(err);
+  }
+};

--- a/src/utils/googleCalendarClient.js
+++ b/src/utils/googleCalendarClient.js
@@ -1,0 +1,36 @@
+import { NotFoundError } from '../errors/error.js';
+import * as GoogleTokenRepository from '../repositories/google-token.repository.js';
+import { google } from 'googleapis';
+
+const CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+const CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+
+export const createOAuthClientForUser = async (userId) => {
+  const tokens = await GoogleTokenRepository.findByUserId(userId);
+  if (!tokens) {
+    throw new NotFoundError('구글 토큰이 존재하지 않음');
+  }
+
+  const oauth2Client = new google.auth.OAuth2(CLIENT_ID, CLIENT_SECRET);
+
+  oauth2Client.setCredentials({
+    access_token: tokens.access_token,
+    refresh_token: tokens.refresh_token,
+  });
+
+  // access_token / refresh_token이 갱신되면 DB에 반영
+  oauth2Client.on('tokens', async (newTokens) => {
+    try {
+      if (newTokens.access_token || newTokens.refresh_token) {
+        await GoogleTokenRepository.updateTokens(userId, {
+          accessToken: newTokens.access_token,
+          refreshToken: newTokens.refresh_token,
+        });
+      }
+    } catch (e) {
+      console.error('Failed to persist refreshed tokens', e);
+    }
+  });
+
+  return oauth2Client;
+};


### PR DESCRIPTION
## Resolve
  - 이슈 태그 
  - #46 

## 구현 기능
  - 구글 캘린더 일정 등록
  : 일정 등록 api와 통합하여 작동. 구글 캘린더에 timeup 이라는 이름의 캘린더 생성하여 저장
  - 구글 캘린더 일정 월별 조회
  : 일정 월별 조회 api와 통합하여 작동. 구글 캘린더에 timeup 캘린더를 제외한 나머지 캘린더에서 검색
  - 구글 캘린더 일정 일별 조회 
  : 일정 일별 조회 api와 통합하여 작동. 구글 캘린더에 timeup 캘린더를 제외한 나머지 캘린더에서 검색
    구글 캘린더로 이동할 수 있는 url 제공

## 구현 상태 (선택)
  - img, gif, video...
  - 혹은 내용 정리

## 리뷰 요구사항 (선택)
  - 리뷰가 필요한 부분이 있다면 작성합니다.
